### PR TITLE
Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Depends:
 Imports: 
     methods,
     Rcpp (>= 0.12.0),
-    rstan (>= 2.18.1),
+    rstan (>= 2.26.0),
     Hmisc (>= 4.3-0),
     survival (>= 3.1-12),
     ggplot2,
@@ -44,8 +44,8 @@ LinkingTo:
     Rcpp (>= 0.12.0),
     RcppEigen (>= 0.3.3.3.0),
     RcppParallel (>= 5.0.1),
-    rstan (>= 2.18.1),
-    StanHeaders (>= 2.18.0)
+    rstan (>= 2.26.0),
+    StanHeaders (>= 2.26.0)
 Suggests:
     cmdstanr,
     bayesplot,

--- a/inst/stan/lrmconppo.stan
+++ b/inst/stan/lrmconppo.stan
@@ -1,8 +1,8 @@
 functions {
   // pointwise log-likelihood contributions
   vector pw_log_lik(vector alpha, vector beta, vector tau, vector pposcore, 
-	                  vector gamma, row_vector[] X, row_vector[] Z, int[,] y,
-										int[] cluster) {
+	                  vector gamma, array[] row_vector X, array[] row_vector Z, array[,] int y,
+										array[] int cluster) {
     int N = size(X);
 		real ll;
     vector[N] out;
@@ -68,10 +68,10 @@ data {
 	int<lower = 0, upper = k> lpposcore;  // extent of pposcore (1=PO)
   matrix[N, p] X;     // matrix of CENTERED predictors
 	matrix[N, q] Z;     // matrix of CENTERED PPO predictors
-  int<lower = 1, upper = k> y[N, 2]; // 2-column outcome on 1 ... k
+  array[N, 2] int<lower = 1, upper = k> y; // 2-column outcome on 1 ... k
 	vector[lpposcore] pposcore; // scores for constrained partial PO
 	int<lower = 0> Nc;  // number of clusters (0=no clustering)
-	int<lower = 1, upper = Nc> cluster[Nc == 0 ? 0 : N];
+	array[Nc == 0 ? 0 : N] int<lower = 1, upper = Nc> cluster;
   
 // prior standard deviations
 	vector<lower = 0>[p] sds;
@@ -79,13 +79,13 @@ data {
   real<lower = 0> conc;
 
   int<lower = 1, upper = 2> psigma;  // 1=t(4, rsdmean[1], rsdsd[1]), 2=exponential
-	real<lower = 0> rsdmean[Nc == 0 ? 0 : 1];
-	real<lower = 0> rsdsd[Nc == 0 || psigma == 2 ? 0 : 1];
+	array[Nc == 0 ? 0 : 1] real<lower = 0> rsdmean;
+	array[Nc == 0 || psigma == 2 ? 0 : 1] real<lower = 0> rsdsd;
 }
 
 transformed data {
-	row_vector[p] Xr[N];
-	row_vector[q] Zr[N];
+	array[N] row_vector[p] Xr;
+	array[N] row_vector[q] Zr;
   for (n in 1:N) Xr[n] = X[n, ];
 	for (n in 1:N) Zr[n] = Z[n, ];
 }
@@ -95,7 +95,7 @@ parameters {
   vector[q] tau;  // coefficients on Z
   simplex[k] pi;  // category probabilities for a person w/ average predictors
 	vector[Nc] gamma_raw;   // unscaled random effects
-	real<lower = 0> sigmag[Nc == 0 ? 0 : 1]; // SD of random effects
+	array[Nc == 0 ? 0 : 1] real<lower = 0> sigmag; // SD of random effects
 }
 
 transformed parameters {

--- a/inst/stan/lrmconppot.stan
+++ b/inst/stan/lrmconppot.stan
@@ -1,8 +1,8 @@
 functions {
   // pointwise log-likelihood contributions
   vector pw_log_lik(vector alpha, vector beta, vector tau, vector pposcore, 
-	                  vector gamma, row_vector[] X, row_vector[] Z, int[,] y,
-										int[] cluster) {
+	                  vector gamma, array[] row_vector X, array[] row_vector Z, array[,] int y,
+										array[] int cluster) {
     int N = size(X);
 		real ll;
     vector[N] out;
@@ -69,10 +69,10 @@ data {
 	int<lower = 0, upper = k> lpposcore;  // extent of pposcore (1=PO)
   matrix[N, p] X;     // matrix of CENTERED predictors
 	matrix[N, q] Z;     // matrix of CENTERED PPO predictors
-  int<lower = 1, upper = k> y[N, 2]; // 2-column outcome on 1 ... k
+  array[N, 2] int<lower = 1, upper = k> y; // 2-column outcome on 1 ... k
 	vector[lpposcore] pposcore; // scores for constrained partial PO
 	int<lower = 0> Nc;  // number of clusters (0=no clustering)
-	int<lower = 1, upper = Nc> cluster[Nc == 0 ? 0 : N];
+	array[Nc == 0 ? 0 : N] int<lower = 1, upper = Nc> cluster;
   
 // prior standard deviations
 	vector<lower = 0>[p] sds;
@@ -81,13 +81,13 @@ data {
 	real<lower = 0.01> ascale;
 
   int<lower = 1, upper = 2> psigma;  // 1=t(4, rsdmean[1], rsdsd[1]), 2=exponential
-	real<lower = 0> rsdmean[Nc == 0 ? 0 : 1];
-	real<lower = 0> rsdsd[Nc == 0 || psigma == 2 ? 0 : 1];
+	array[Nc == 0 ? 0 : 1] real<lower = 0> rsdmean;
+	array[Nc == 0 || psigma == 2 ? 0 : 1] real<lower = 0> rsdsd;
 }
 
 transformed data {
-	row_vector[p] Xr[N];
-	row_vector[q] Zr[N];
+	array[N] row_vector[p] Xr;
+	array[N] row_vector[q] Zr;
   for (n in 1:N) Xr[n] = X[n, ];
 	for (n in 1:N) Zr[n] = Z[n, ];
 }
@@ -97,7 +97,7 @@ parameters {
   vector[p] beta; // coefficients on X
   vector[q] tau;  // coefficients on Z
 	vector[Nc] gamma_raw;   // unscaled random effects
-	real<lower = 0> sigmag[Nc == 0 ? 0 : 1]; // SD of random effects
+	array[Nc == 0 ? 0 : 1] real<lower = 0> sigmag; // SD of random effects
 }
 
 transformed parameters {

--- a/inst/stan/lrmcppo.stan
+++ b/inst/stan/lrmcppo.stan
@@ -2,7 +2,7 @@
 functions {
   // pointwise log-likelihood contributions
   vector pw_log_lik(vector alpha, vector beta, matrix tau, vector gamma,
-	                  row_vector[] X, row_vector[] Z, int[] y, int[] cluster) {
+	                  array[] row_vector X, array[] row_vector Z, array[] int y, array[] int cluster) {
     int N = size(X);
     vector[N] out;
     int k = max(y); // assumes all possible categories are observed
@@ -30,7 +30,7 @@ functions {
   
   // Pr(y == j)
   matrix Pr(vector alpha, vector beta, matrix tau, vector gamma,
-	          row_vector[] X, row_vector[] Z, int[] y, int[] cluster) {
+	          array[] row_vector X, array[] row_vector Z, array[] int y, array[] int cluster) {
     int N = size(X);
     int k = max(y); // assumes all possible categories are observed
     matrix[N, k] out;
@@ -63,24 +63,24 @@ data {
   matrix[N, p] X;     // matrix of CENTERED predictors
 	matrix[N, q] Z;     // matrix of CENTERED PPO predictors
   int<lower = 2> k;   // number of outcome categories
-  int<lower = 1, upper = k> y[N]; // outcome on 1 ... k
-  int<lower = 1, upper = Nc> cluster[Nc == 0 ? 0 : N];  // cluster IDs
+  array[N] int<lower = 1, upper = k> y; // outcome on 1 ... k
+  array[Nc == 0 ? 0 : N] int<lower = 1, upper = Nc> cluster;  // cluster IDs
   
   // prior standard deviations
   vector<lower = 0>[p] sds;
 	vector<lower = 0>[q] sdsppo;
 
   int<lower = 1, upper = 2> psigma;  // 1=t(4, rsdmean, rsdsd); 2=exponential
-  real<lower = 0> rsdmean[Nc == 0 ? 0 : 1];  // mean of prior for sigma
-  real<lower = 0> rsdsd[Nc == 0 || psigma == 2 ? 0 : 1];
+  array[Nc == 0 ? 0 : 1] real<lower = 0> rsdmean;  // mean of prior for sigma
+  array[Nc == 0 || psigma == 2 ? 0 : 1] real<lower = 0> rsdsd;
 	// scale parameter for sigma (used only if psigma=1)
 
   real<lower = 0> conc;
 }
 
 transformed data {
-  row_vector[p] Xr[N];
-  row_vector[q] Zr[N];
+  array[N] row_vector[p] Xr;
+  array[N] row_vector[q] Zr;
   
   for (n in 1:N) Xr[n] = X[n, ];
   for (n in 1:N) Zr[n] = Z[n, ];
@@ -91,7 +91,7 @@ parameters {
   matrix[q, k - 2] tau;  // coefficients on Z
   simplex[k] pi;  // category probabilities for a person w/ average predictors
   vector[Nc] gamma_raw;  // unscaled random effects
-  real<lower = 0> sigmag[Nc == 0 ? 0 : 1];   // SD of random effects
+  array[Nc == 0 ? 0 : 1] real<lower = 0> sigmag;   // SD of random effects
 }
 
 transformed parameters {


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
